### PR TITLE
derive the `Debug` trait for a handful of internal data structures

### DIFF
--- a/crates/pairstat_nostd_internal/Cargo.toml
+++ b/crates/pairstat_nostd_internal/Cargo.toml
@@ -9,6 +9,26 @@ rust-version.workspace = true
 repository.workspace = true
 
 
+# in addition to regular usage, we are planning to experiment with this crate
+# in using GPUs. In that scenario, we would need to use it in:
+# 1. a CUDA GPU crate that compiles to PTX
+# 2. a CPU crate that launches the CUDA kernels
+#
+# For that reason, we want to put some features behind feature-flags so we
+# can disable them in certain contexts. For example, the Rust-CUDA docs advise
+# against deriving Debug traits to avoid unnecessarily increasing the size of
+# the GPU crates
+# https://rust-gpu.github.io/Rust-CUDA/guide/tips.html?highlight=elimin#gpu-kernels
+#
+# We are going to start out defining more fine-grained features, and if necessary,
+# we'll them down later...
+[features]
+default = ["fmt"]
+
+# when enabled we define some formatting traits (enabled by default)
+fmt=[]
+
+
 [dependencies]
 # we disable default-features since this crate is no-std
 ndarray = { version = "0.16", default-features = false }

--- a/crates/pairstat_nostd_internal/src/bins.rs
+++ b/crates/pairstat_nostd_internal/src/bins.rs
@@ -14,6 +14,7 @@ pub trait BinEdges {
 
 /// Regular bins with uniform spacing
 #[derive(Clone)]
+#[cfg_attr(feature = "fmt", derive(Debug))]
 pub struct RegularBinEdges {
     min: f64,
     max: f64,
@@ -95,6 +96,7 @@ pub fn validate_bin_edges(edges: &[f64]) -> Result<(), &'static str> {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "fmt", derive(Debug))]
 pub struct IrregularBinEdges<'a> {
     bin_edges: &'a [f64],
 }

--- a/crates/pairstat_nostd_internal/src/misc.rs
+++ b/crates/pairstat_nostd_internal/src/misc.rs
@@ -71,6 +71,7 @@ fn check_shape(shape_zyx: &[usize; 3]) -> Result<(), &'static str> {
 /// common shape and data layout.
 #[allow(dead_code)] // this is a temporary stopgap solution
 #[derive(Clone)]
+#[cfg_attr(feature = "fmt", derive(Debug))]
 pub struct View3DSpec {
     // Developer Notes
     // ---------------

--- a/crates/pairstat_nostd_internal/src/twopoint/common.rs
+++ b/crates/pairstat_nostd_internal/src/twopoint/common.rs
@@ -5,6 +5,7 @@
 /// necessary to convert this to a trait (each variant would become a
 /// unit-like struct)
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "fmt", derive(Debug))]
 pub enum PairOperation {
     /// For a pair of vector measurements, compute the element-wise
     /// products. This is used to compute correlation functions

--- a/crates/pairstat_nostd_internal/src/twopoint/spatial.rs
+++ b/crates/pairstat_nostd_internal/src/twopoint/spatial.rs
@@ -7,6 +7,7 @@ use crate::misc::View3DSpec;
 // it might make more sense to provide this in a separate format that reduces
 // round-off error (e.g, global_domain_width and global_domain_shape)
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "fmt", derive(Debug))]
 pub struct CellWidth {
     pub(crate) widths_zyx: [f64; 3],
 }
@@ -22,6 +23,7 @@ impl CellWidth {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "fmt", derive(Debug))]
 pub struct CartesianBlock<'a> {
     pub(crate) value_components_zyx: [&'a [f64]; 3],
     pub(crate) weights: &'a [f64],

--- a/crates/pairstat_nostd_internal/src/twopoint/unstructured.rs
+++ b/crates/pairstat_nostd_internal/src/twopoint/unstructured.rs
@@ -18,6 +18,7 @@ use ndarray::ArrayView2;
 ///   where `D` is the number of spatial dimensions and `n_points` is the
 ///   number of points.
 #[derive(Clone)]
+#[cfg_attr(feature = "fmt", derive(Debug))]
 pub struct UnstructuredPoints<'a> {
     positions: ArrayView2<'a, f64>,
     // TODO allow values to have a different dimensionality than positions


### PR DESCRIPTION
These are only conditionally defined. The rationale for doing this is explained in the modified `Cargo.toml` file